### PR TITLE
Updated README with _ delimiters used for file names and directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,29 +136,29 @@ However all three build tools can be used with both combinations of test files. 
 
 ```bash
 # appcode directory option
-project-root/
+project_root/
   |- test/
   |- app/
     |- scripts/
       |- apps/
         |- home/                         # feature folder
-          |- home-controller.js          # actual file
-          |- home-controller-test.js     # actual test file
+          |- home_controller.js          # actual file
+          |- home_controller_test.js     # actual test file
           ...
 ```
 
 ```bash
 # separate directory option
-project-root/
+project_root/
   |- test/
     |- apps/
       |- home/
-        |- home-controller-test.js       # actual test file
+        |- home_controller_test.js       # actual test file
   |- app/
     |- scripts/
       |- apps/
         |- home/                         # feature folder
-          |- home-controller.js          # actual file
+          |- home_controller.js          # actual file
           ...
 ```
 
@@ -170,11 +170,11 @@ Appart from invoking the main generator. Marionette generator comes with couple 
 
 Marionette generator comes with baked in code style guides and naming conventions. It is important that you know what some these conventions are before you start using the generator to keep the code consistent.
 
-The most important is the difference between the **file naming conventions** and the **variable naminng coventions**. **Files** follow the **hypen case** (my-file-model.js) where **variables/contructors** follow the **camel case** (MyModel, MyCollection) conventions.
+The most important is the difference between the **file naming conventions** and the **variable naminng coventions**. **Files** follow the **snake case** (my_file_model.js) where **variables/contructors** follow the **camel case** (MyModel, MyCollection) conventions.
 
 Note: In order for the generator to work properly each **sub-generator expects the file names  to be hyphen case** so it can automatically convert the name into the camel case when needed.
 
-Templates (-t, --template) are also important. Generator is expecting from you that your custom template file will be in form `name-template.hbs` or `name-view-type-template.hbs`. Which means `name.hbs` will not work.
+Templates (-t, --template) are also important. Generator is expecting from you that your custom template file will be in form `name_template.hbs` or `name_view_type_template.hbs`. Which means `name.hbs` will not work.
 
 ### Output Directory
 
@@ -182,20 +182,20 @@ All sub-generators place the generated output in the `app/scripts/apps` folder b
 If the `--directory` option is not specified an empty directory will be created (named after the generated component).
 
 ```
-$ yo mario:model my-model
+$ yo mario:model my_model
 ```
 
-will create a my-model folder as follows:
+will create a my_model folder as follows:
 
 ```bash
-project-root/
+project_root/
   |- test/
   |- app/
     |- scripts/
       |- apps/
-        |- my-model/              # feature folder
-          |- my-model.js          # actual file
-          |- my-model-test.js     # actual test file
+        |- my_model/              # feature folder
+          |- my_model.js          # actual file
+          |- my_model_test.js     # actual test file
 ```
 
 ### Option Flags
@@ -219,10 +219,10 @@ It is possible to change the default behavior of a sub-generator by specifying o
 
 All these options have a *path* parameter. There are 2 ways you can specify a path to a file that mario generator accepts:
 
-- relative to *project root* (in form of `app/scripts/apps/my-model/my-model.js`)
-- relative to *feature folder* (`my-model.js` or `my-nested-folder/my-model.js`)
+- relative to *project root* (in form of `app/scripts/apps/my_model/my_model.js`)
+- relative to *feature folder* (`my_model.js` or `my_nested_folder/my_model.js`)
 
-Note: Invoking sub-generators with path parameters only work from the project root folder. Otherwise it will mix the paths. It is also not possible to create files outside the *apps* folder. Invoking with path `app/scripts/my-custom/folder` will result in a custom `app/scripts/my-custom/folder` inside the *apps* directory.
+Note: Invoking sub-generators with path parameters only work from the project root folder. Otherwise it will mix the paths. It is also not possible to create files outside the *apps* folder. Invoking with path `app/scripts/my_custom/folder` will result in a custom `app/scripts/my_custom/folder` inside the *apps* directory.
 
 ## Sub-generators
 All supported sub-generators with their descriptions can be found below:
@@ -241,189 +241,189 @@ All supported sub-generators with their descriptions can be found below:
 ### Model
 Model is generated via command:
 
-`yo mario:model <model-name> [--directory <folder-name>]`
+`yo mario:model <model_name> [--directory <folder_name>]`
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <model-name>-model.js
-      |- <model-name>-model-test.js
+ <folder_name>/
+      |- <model_name>_model.js
+      |- <model_name>_model_test.js
 ```
 ### Collection
 Collection is generated via command:
 
-`yo mario:collection <collection-name> [--directory <folder-name> --model <model-name>]`
+`yo mario:collection <collection_name> [--directory <folder_name> --model <model_name>]`
 
 This command will generate only collection and collection test and it uses specified existed model.
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <collection-name>-collection.js
-      |- <collection-name>-collection-test.js
+ <folder_name>/
+      |- <collection_name>_collection.js
+      |- <collection_name>_collection_test.js
 ```
 
 If you want to create also model to this collection, use the command:
 
-`yo mario:collection <collection-name> [--directory <folder-name>]`
+`yo mario:collection <collection_name> [--directory <folder_name>]`
 
 Generating collection with this command will cause also generating new model and its test.
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <collection-name>-collection.js
-      |- <collection-name>-collection-test.js
-      |- <model-name>-model.js
+ <folder_name>/
+      |- <collection_name>_collection.js
+      |- <collection_name>_collection_test.js
+      |- <model_name>_model.js
 ```
 ### Item View
 Item view is generated via command:
 
-`yo mario:itemview <item-view-name> [--directory <folder-name> --template <itemview-template-name>]`
+`yo mario:itemview <item_view_name> [--directory <folder_name> --template <itemview_template_name>]`
 
-The <itemview-template-name> should be full name of already existing template. This will generate item view and reuse the specified template.
+The <itemview_template_name> should be full name of already existing template. This will generate item view and reuse the specified template.
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <item-view-name>-item-view.js
-      |- <item-view-name>-item-view-test.js
+ <folder_name>/
+      |- <item_view_name>_item_view.js
+      |- <item_view_name>_item_view_test.js
 ```
 
 Typing command without template flag will cause generating item view with new template.
 
-`yo mario:itemview <item-view-name> [--directory <folder-name>]`
+`yo mario:itemview <item_view_name> [--directory <folder_name>]`
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <item-view-name>-item-view.js
-      |- <item-view-name>-item-view-test.js
-      |- <item-view-name>-template.hbs
+ <folder_name>/
+      |- <item_view_name>_item_view.js
+      |- <item_view_name>_item_view_test.js
+      |- <item_view_name>_template.hbs
 ```
 ### Collection View
 Collection view is generated via command:
 
-`yo mario:collectionview <collection-view-name> [--directory <folder-name> --itemview <item-view-name>]`
+`yo mario:collectionview <collection_view_name> [--directory <folder_name> --itemview <item_view_name>]`
 
 This command will generate only collection-view and its test. As a child view there will be used specified item view.
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <collection-view-name>-collection-view.js
-      |- <collection-view-name>-collection-view-test.js
+ <folder_name>/
+      |- <collection_view_name>_collection_view.js
+      |- <collection_view_name>_collection_view_test.js
 ```
 
 Collection view can be also generated without flags for child view and template:
 
-`yo mario:collectionview <collection-view-name> [--directory <folder-name>]`
+`yo mario:collectionview <collection_view_name> [--directory <folder_name>]`
 
 This command will generate also new item view as a child view and new template.
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <collection-view-name>-collection-view.js
-      |- <collection-view-name>-collection-view-test.js
-      |- <item-view-name>-item-view.js
-      |- <item-view-name>-item-view-test.js
-      |- <item-view-name>-item-view-template.hbs
+ <folder_name>/
+      |- <collection_view_name>_collection_view.js
+      |- <collection_view_name>_collection_view_test.js
+      |- <item_view_name>_item_view.js
+      |- <item_view_name>_item_view_test.js
+      |- <item_view_name>_item_view_template.hbs
 ```
 ### Composite View
 Collection view is generated via command:
 
-`yo mario:compositeview <composite-view-name> [--directory <folder-name> --itemview <item-view-name> --template <compositeview-template-name>]`
+`yo mario:compositeview <composite_view_name> [--directory <folder_name> --itemview <item_view_name> --template <compositeview_template_name>]`
 
-The <compositeview-template-name> and <itemview-template-name> should be full names of already existing templates for composite view and for item view. This command will generate only collection-view and its test. As a child view there will be used specified item view, the for the template it will be used specified composite view template.
+The <compositeview_template_name> and <itemview_template_name> should be full names of already existing templates for composite view and for item view. This command will generate only collection_view and its test. As a child view there will be used specified item view, the for the template it will be used specified composite view template.
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <composite-view-name>-composite-view.js
-      |- <composite-view-name>-composite-view-test.js
+ <folder_name>/
+      |- <composite_view_name>_composite_view.js
+      |- <composite_view_name>_composite_view_test.js
 ```
 
 Collection view can be also generated without flags for reusing item view and without reusing composite view template:
 
-`yo mario:collectionview <collection-view-name> [--directory <folder-name>]`
+`yo mario:collectionview <collection_view_name> [--directory <folder_name>]`
 
 This command will generate new item view, new item view template and new composite view template.
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <composite-view-name>-composite-view.js
-      |- <composite-view-name>-composite-view-test.js
-      |- <composite-view-name>-composite-view-template.hbs
-      |- <item-view-name>-item-view.js
-      |- <item-view-name>-item-view-test.js
-      |- <item-view-name>-template.hbs
+ <folder_name>/
+      |- <composite_view_name>_composite_view.js
+      |- <composite_view_name>_composite_view_test.js
+      |- <composite_view_name>_composite_view_template.hbs
+      |- <item_view_name>_item_view.js
+      |- <item_view_name>_item_view_test.js
+      |- <item_view_name>_template.hbs
 ```
 
 ### Layout View
 Layout view is generated via command:
 
-`yo mario:layoutview <layout-view-name> [--directory <folder-name> --template <layoutview-template-name>]`
+`yo mario:layoutview <layout_view_name> [--directory <folder_name> --template <layoutview_template_name>]`
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <layout-view-name>-layout-view.js
-      |- <layout-view-name>-layout-view-test.js
+ <folder_name>/
+      |- <layout_view_name>_layout_view.js
+      |- <layout_view_name>_layout_view_test.js
 ```
 
 Layout view can be also generated without flag for reusing layout view template:
 
-`yo mario:layoutview <layout-view-name> [--directory <folder-name>]`
+`yo mario:layoutview <layout_view_name> [--directory <folder_name>]`
 
 This command will generate new item view, new item view template and new composite view template.
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <layout-view-name>-layout-view.js
-      |- <layout-view-name>-layout-view-test.js
-      |- <layout-view-name>-layout-view-template.hbs
+ <folder_name>/
+      |- <layout_view_name>_layout_view.js
+      |- <layout_view_name>_layout_view_test.js
+      |- <layout_view_name>_layout_view_template.hbs
 ```
 
 ### Router
 Router is generated via command:
 
-`yo mario:router <router-name> [--directory <folder-name> --controller <controller-name>]`
+`yo mario:router <router_name> [--directory <folder_name> --controller <controller_name>]`
 
 This will generate only router and as a controller there will be used specified controller.
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <router-name>-router.js
+ <folder_name>/
+      |- <router_name>_router.js
 ```
 
 Second command for generation of router:
 
-`yo mario:router <router-name> [--directory <folder-name>]`
+`yo mario:router <router_name> [--directory <folder_name>]`
 
 This will generate router and also new controller.
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <router-name>-router.js
-      |- <controller-name>-controller.js
+ <folder_name>/
+      |- <router_name>_router.js
+      |- <controller_name>_controller.js
 ```
 ### Controller
 A controller contains the logic behind your application. It controls views and data sent into and from the views. Controller is also responsible for communicating with other components of your application via the channeling system (Backbone.Radio).
@@ -432,18 +432,18 @@ A controller sub-generator is capable of generating template controller file. Us
 
 Controller is generated via command:
 
-`yo mario:controller <controller-name> [--directory <folder-name>] [[-m <path-to-model> --itv <path-to-item-view] | [-c <path-to-collection> --clv <path-to-collectionview>] | [-m <path-to-model> -c <path-to-collection> --cmv <path-to-composite-view>]]`
+`yo mario:controller <controller_name> [--directory <folder_name>] [[-m <path_to_model> --itv <path_to_item_view] | [-c <path_to_collection> --clv <path_to_collectionview>] | [-m <path_to_model> -c <path_to_collection> --cmv <path_to_composite_view>]]`
 
 Generated file structure:
 
 ```
- <folder-name>/
-      |- <controller-name>-controller.js
+ <folder_name>/
+      |- <controller_name>_controller.js
 ```
 ### Crud
 
 Generate crud feature with:
-`yo mario:crud <crud-name> [--directory <folder-name>]`
+`yo mario:crud <crud_name> [--directory <folder_name>]`
 
 CRUD stands for
 - create
@@ -473,13 +473,13 @@ The newly generated feature will have its name a route prefix.
 
 will result in
 
-`your-domain/projects/(list | create | detail)`
+`your_domain/projects/(list | create | detail)`
 
 routes.
 
 ### Widget
 Generate widget feature with:
-`yo mario:widget <widget-name> [--directory <folder-name>]`
+`yo mario:widget <widget_name> [--directory <folder_name>]`
 
 Widget is mix of several backbone and marionette building blocks.
 
@@ -522,11 +522,11 @@ Marionette generator does this in an opinionated way that we think is a way for 
 
 ### Scaffolding Initial Project Structure
 
-We start with creating a empty directory where all of out generated code will be placed. Lets say that the project's base folder will be called *Fruit Project*. The generator expects us to use hypen-case naming convention for files, so to stay consistent, we'll use *frunt-project* as the name for the folder:
+We start with creating a empty directory where all of out generated code will be placed. Lets say that the project's base folder will be called *Fruit Project*. The generator expects us to use snake_case naming convention for files, so to stay consistent, we'll use *frunt_project* as the name for the folder:
 
 ```bash
 # create a empty folder
-$ mkdir fruit-project
+$ mkdir fruit_project
 
 # change current directory to our newly created folder
 $ cd fruit
@@ -542,8 +542,8 @@ $ yo mario
 The generator now asks several questions like the app name etc.
 
 ```
-? How would you like to name your application? (mario-app) fruit-app
-fruit-app
+? How would you like to name your application? (mario-app) fruit_app
+fruit_app
 ? What build tool would you like to use? grunt
 ? Which version of ECMAScript Standard would you like to use? ECMAScript 5 (ES5)
 ? Where would you like to store your test files? Separately
@@ -571,19 +571,19 @@ Let us start with a simple model
 ```bash
 $ yo mario:model fruit
 
-create app\scripts\apps\fruit\fruit-model.js
-create app\scripts\apps\fruit\fruit-model-test.js
+create app\scripts\apps\fruit\fruit_model.js
+create app\scripts\apps\fruit\fruit_model_test.js
 ```
 
-The model sub-generator generated 2 files, model and a dummy test for the model. We did not specify directory in which the generator should put the files, so it created an empty directory with the same name as the model a put the stuff there. Also notice that the generator automatically added *-model* suffix to the file name.
+The model sub-generator generated 2 files, model and a dummy test for the model. We did not specify directory in which the generator should put the files, so it created an empty directory with the same name as the model a put the stuff there. Also notice that the generator automatically added *_model* suffix to the file name.
 
-Next lets create a collection that will use our *fruit-model*.
+Next lets create a collection that will use our *fruit_model*.
 
 ```bash
-$ yo mario:collection fruit -m fruit-model
+$ yo mario:collection fruit -m fruit_model
 
-create app\scripts\apps\fruit\fruit-collection.js
-create app\scripts\apps\fruit\fruit-collection-test.js
+create app\scripts\apps\fruit\fruit_collection.js
+create app\scripts\apps\fruit\fruit_collection_test.js
 ```
 
 Again we got 2 new files a collection and a test for the collection. Notice that the collection is generated in the same directory as the model. This is because we did not specify the directory and the names (for the model and the collection) are the same e.g. *fruit*.
@@ -592,10 +592,10 @@ We could have specified the model in collection sub-generator in multi ways.
 ```bash
 # generate a collection named fruit in the default directory (fruit in this case)
 $ yo mario:collection fruit -m fruit
-$ yo mario:collection fruit -m fruit-model
-$ yo mario:collection fruit -m fruit-model.js
-$ yo mario:collection fruit -m app/scripts/apps/fruit/fruit-model
-$ yo mario:collection fruit -m app/scripts/apps/fruit/fruit-model.js
+$ yo mario:collection fruit -m fruit_model
+$ yo mario:collection fruit -m fruit_model.js
+$ yo mario:collection fruit -m app/scripts/apps/fruit/fruit_model
+$ yo mario:collection fruit -m app/scripts/apps/fruit/fruit_model.js
 ```
 
 All of the above are equivalent for the particular case with name *fruit*.
@@ -605,9 +605,9 @@ OK, so we have the model and collection that uses the model. This is all great b
 
 ```bash
 $ yo mario:itemview fruit
-create app\scripts\apps\fruit\fruit-item-view.js
-create app\scripts\apps\fruit\fruit-item-view-template.hbs
-create app\scripts\apps\fruit\fruit-item-view-test.js
+create app\scripts\apps\fruit\fruit_item_view.js
+create app\scripts\apps\fruit\fruit_item_view_template.hbs
+create app\scripts\apps\fruit\fruit_item_view_test.js
 ```
 
 This time we got 3 files out of the generator. This is because item view creates a dummy template when there is no template specified as the option flag (-t).
@@ -615,20 +615,20 @@ This time we got 3 files out of the generator. This is because item view creates
 Just for the sake of demonstration, we'll put the collection view in a separate directory. Keep in mind that it is encouraged to have all feature related files in the same flat directory, as long as possible (you may end up refactoring the feature code into several directories when the complexity / number of files grows).
 
 ```bash
-$ yo mario:collectionview fruit -d fruit/list --itv fruit/fruit-item-view
-create app\scripts\apps\fruit\list\fruit-collection-view.js
-create app\scripts\apps\fruit\list\fruit-collection-view-test.js
+$ yo mario:collectionview fruit -d fruit/list --itv fruit/fruit_item_view
+create app\scripts\apps\fruit\list\fruit_collection_view.js
+create app\scripts\apps\fruit\list\fruit_collection_view_test.js
 ```
 
 Again we got component file and a test for it. And once more we could have specified the directory & view option paths multiple ways. Here are some equivalent notations:
 
 ```bash
-# generate collection view with name fruit (collection postfix gets added automatically), in fruit/list directory with item view name fruit(-item-view) from the fruit directory
+# generate collection view with name fruit (collection postfix gets added automatically), in fruit/list directory with item view name fruit(_item_view) from the fruit directory
 $ yo mario:collectionview fruit -d app/scripts/apps/fruit/list --itv fruit/fruit
 
 $ yo mario:collectionview fruit -d fruit/list --itv fruit/fruit
-$ yo mario:collectionview fruit -d fruit/list --itv fruit/fruit-item-view
-$ yo mario:collectionview fruit -d fruit/list --itv fruit/fruit-item-view.js
+$ yo mario:collectionview fruit -d fruit/list --itv fruit/fruit_item_view
+$ yo mario:collectionview fruit -d fruit/list --itv fruit/fruit_item_view.js
 ```
 
 Now that we have all the boiler code generated we want to put all these components together and display a list of fruits. We need to modify app.js file to be able to do that.
@@ -639,8 +639,8 @@ Import both collection and collection view.
 ```javascript
 define([
     ...
-    'apps/fruit/list/fruit-collection-view',
-    'apps/fruit/fruit-collection'
+    'apps/fruit/list/fruit_collection_view',
+    'apps/fruit/fruit_collection'
 ], function (
     ...
     FruitCollectionView,
@@ -660,7 +660,7 @@ var initializeUI = function () {
     };
 ```
 
-The last thing to do is to modify the fruit template to show the name of the fruit, *app/scripts/apps/fruit-item-view-template*:
+The last thing to do is to modify the fruit template to show the name of the fruit, *app/scripts/apps/fruit_item_view_template*:
 ```html
 <div>
   <h2>{{id}} - {{name}}</h2>


### PR DESCRIPTION
Replaced the old `spinal-case` naming convention with `snake_case` one in README file.
This is what the generator is actually producing.
